### PR TITLE
feat: add configuration option to disable active sync to save battery

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,12 +10,17 @@ var currentConfigPath string
 // LEVEL 0
 
 type Config struct {
+	Global    GlobalConfig    `json:"global"`
 	Playerctl PlayerctlConfig `json:"playerctl"`
 	Cache     CacheConfig     `json:"cache"`
 	Output    OutputConfig    `json:"output"`
 }
 
 // LEVEL 1
+
+type GlobalConfig struct {
+	DisableActiveSync bool `json:"disableActiveSync"`
+}
 
 type PlayerctlConfig struct {
 	IncludedPlayers            []string `json:"includedPlayers"`
@@ -127,6 +132,9 @@ func (r *RomanizationConfig) IsEnabled() bool {
 }
 
 var defaultConfig = Config{
+	Global: GlobalConfig{
+		DisableActiveSync: false,
+	},
 	Playerctl: PlayerctlConfig{
 		IncludedPlayers:            []string{},
 		ExcludedPlayers:            []string{},


### PR DESCRIPTION
The following addition grants laptop users a better control over power consumption of the syncing process.
Usually the sync process requests position data each 0.1s to be actively in sync with player, but the added configuration option changes the value to be 1s with the following sync concept change.
This, however, impacts syncing for the players that use seconds as position data, such as cmus. 